### PR TITLE
fix goroutine leak

### DIFF
--- a/cmd/localrelay/main.go
+++ b/cmd/localrelay/main.go
@@ -138,11 +138,6 @@ func (ligolo LigoloRelay) handleLocalConnection(conn net.Conn) {
 	go relay(conn, stream)
 	go relay(stream, conn)
 
-	select {
-	case <-ligolo.Session.CloseChan():
-		logrus.WithFields(logrus.Fields{"remoteaddr": ligolo.Session.RemoteAddr().String()}).Println("Connection closed.")
-		return
-	}
 }
 
 // Handle new ligolo connections


### PR DESCRIPTION
func (ligolo LigoloRelay) handleLocalConnection(conn net.Conn) hang until recv ligolo.Session 's signal 
=> handleLocalConnection never return => goroutine leak


pprof profile
![image](https://user-images.githubusercontent.com/17930973/86217055-21410d80-bba9-11ea-81ac-95e80d4d0f28.png)

[goroutine.zip](https://github.com/sysdream/ligolo/files/4856382/goroutine.zip)
