### PR TITLE
Makefile update for newer go versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help: ## Show Help
 
 dep: ## Install dependencies
 	go get -d -v ./...
-	go get -u github.com/mitchellh/gox
+	go install -v github.com/mitchellh/gox@latest
 
 certs: ## Build SSL certificates
 	mkdir certs

--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,5 @@ build-all: ## Build for every architectures.
 
 clean:
 	rm -rf certs
-	rm bin/$(LIGOLO_BINARY)_*
-	rm bin/$(RELAY_BINARY)_*
+	rm bin/$(LIGOLO_BINARY)*
+	rm bin/$(RELAY_BINARY)*


### PR DESCRIPTION
Since Go v1.17, `go get` for installing executables is deprecated and instead `go install` is used.
Reference: https://go.dev/doc/go-get-install-deprecation

Also fixed the `make clean` command to properly clean all the compiled binaries